### PR TITLE
Updated Play to version 2.5.8

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -36,13 +36,13 @@ object HmrcBuild extends Build {
 object Dependencies {
 
   object Compile {
-    val play = "com.typesafe.play" %% "play" % "2.3.10" % "provided"
-    val playJson = "com.typesafe.play" %% "play-json" % "2.3.10" % "provided"
+    val play = "com.typesafe.play" %% "play" % "2.5.8" % "provided"
+    val playJson = "com.typesafe.play" %% "play-json" % "2.5.8" % "provided"
   }
 
   sealed abstract class Test(scope: String) {
-    val scalatestplusPlay = "org.scalatestplus" %% "play" % "1.2.0" % scope
-    val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % scope
+    val scalatestplusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % scope
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0" % scope
     val pegdown = "org.pegdown" % "pegdown" % "1.5.0" % scope
   }
 

--- a/src/test/scala/play/api/mvc/hal/HalWriteController.scala
+++ b/src/test/scala/play/api/mvc/hal/HalWriteController.scala
@@ -1,9 +1,8 @@
 package play.api.mvc.hal
 
+import play.api.hal._
 import play.api.libs.json.Json
 import play.api.mvc._
-import play.api.hal._
-import play.api.mvc.hal._
 
 trait HalWriteController {
   this: Controller =>


### PR DESCRIPTION
Required to enable consuming APIs to upgrade to Play 2.5.8