### PR TITLE
TXMNT-626 upgrade to Play 2.5.12

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -36,8 +36,8 @@ object HmrcBuild extends Build {
 object Dependencies {
 
   object Compile {
-    val play = "com.typesafe.play" %% "play" % "2.5.8" % "provided"
-    val playJson = "com.typesafe.play" %% "play-json" % "2.5.8" % "provided"
+    val play = "com.typesafe.play" %% "play" % "2.5.12" % "provided"
+    val playJson = "com.typesafe.play" %% "play-json" % "2.5.12" % "provided"
   }
 
   sealed abstract class Test(scope: String) {


### PR DESCRIPTION
As part of the Play 2.5 upgrade, PlatOps need to try and standardize on v.2.5.12. This is a modification from the previously adopted 2.5.8 in order to pick up fixes in Play for https://github.com/playframework/playframework/issues/6801